### PR TITLE
Fixed PinCommand wrong function call

### DIFF
--- a/source/commands/text/PinCommand.js
+++ b/source/commands/text/PinCommand.js
@@ -16,7 +16,7 @@ class PinCommand extends Command {
             channel.send(`${message.author.toString()} ` + messageText);
             message.delete();
 
-            elia.loggingComponent.log.log(
+            elia.loggingComponent.log(
                 message.author.username + " pinned a message"
             );
         }


### PR DESCRIPTION
A PinCommand rosszul hívta LoggingComponent log() fügvényét. A hibát javítottam.